### PR TITLE
fix prompt toolkit import

### DIFF
--- a/src/Bard.py
+++ b/src/Bard.py
@@ -6,7 +6,8 @@ import re
 import sys
 import string
 import requests
-from prompt_toolkit import prompt, PromptSession, AutoSuggestFromHistory
+from prompt_toolkit import prompt, PromptSession
+from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
 from prompt_toolkit.completion import WordCompleter
 from prompt_toolkit.history import InMemoryHistory
 from prompt_toolkit.key_binding import KeyBindings


### PR DESCRIPTION
it looks like the latest commit broke the import
```py
  File "/home/imp/bard/venv/lib/python3.9/site-packages/Bard.py", line 9, in <module>
    from prompt_toolkit import prompt, PromptSession, AutoSuggestFromHistory

ImportError: cannot import name 'AutoSuggestFromHistory' from 'prompt_toolkit' (/home/imp/bard/venv/lib/python3.9/site-packages/prompt_toolkit/__init__.py)
```