### PR TITLE
dashes in environmental vars cause problems, so i got rid of them

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -22,8 +22,10 @@ class AsyncChatbot()
 
 A class to interact with Google Bard.
 Parameters
-    session_id: str
-        The __Secure-1PSID cookie.
+    session: str
+        The __Secure_1PSID cookie.
+    session_ts: str
+        The __Secure_1PSIDTS cookie
     proxy: str
     timeout: int
         Request timeout in seconds.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Go to https://bard.google.com/
 
 - F12 for console
 - Copy the values
-  - Session: Go to Application → Cookies → `__Secure_1PSID` and `__Secure_1PSIDTS`. Copy the value of those cookie.
+  - Session: Go to Application → Cookies → `__Secure-1PSID` and `__Secure-1PSIDTS`. Copy the value of those cookie.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -11,24 +11,24 @@ Go to https://bard.google.com/
 
 - F12 for console
 - Copy the values
-  - Session: Go to Application → Cookies → `__Secure-1PSID` and `__Secure-1PSIDTS`. Copy the value of those cookie.
+  - Session: Go to Application → Cookies → `__Secure_1PSID` and `__Secure_1PSIDTS`. Copy the value of those cookie.
 
 ## Usage
 
 ```bash
 $ python3 -m Bard -h
-usage: Bard.py [-h] --session SESSION
+usage: Bard.py [-h] --session $BARD__Secure_1PSID --session_ts $BARD__Secure_1PSIDTS
 
 options:
   -h, --help         show this help message and exit
-  --__Secure_1PSID --__Secure_1PSIDTS       pass two cookies
+  --session --session_ts       pass two cookies
 ```
 
 ### Quick mode
 ```
 $ export BARD_QUICK="true"
-$ export BARD___Secure-1PSID="<__Secure-1PSID>"
-$ export BARD___Secure-1PSIDTS="<__Secure-1PSIDTS>"
+$ export BARD__Secure_1PSID="<__Secure_1PSID>"
+$ export BARD__Secure_1PSIDTS="<__Secure_1PSIDTS>"
 $ python3 -m Bard
 ```
 Environment variables can be placed in .zshrc.
@@ -39,8 +39,8 @@ Example bash shortcut:
 # USAGE2: echo "QUESTION" | bard
 bard () {
 	export BARD_QUICK=true
-	export BARD___Secure-1PSID==<REDACTED>.
-	export BARD___Secure-1PSIDTS==<REDACTED>.
+	export BARD__Secure_1PSID==<REDACTED>.
+	export BARD__Secure_1PSIDTS==<REDACTED>.
 	python3 -m Bard "${@:-$(</dev/stdin)}" | tail -n+7
 }
 ```
@@ -50,8 +50,8 @@ bard () {
 from os import environ
 from Bard import Chatbot
 
-Secure_1PSID = environ.get("BARD__Secure-1PSID")
-Secure_1PSIDTS = environ.get("BARD__Secure-1PSIDTS")
+Secure_1PSID = environ.get("BARD__Secure_1PSID")
+Secure_1PSIDTS = environ.get("BARD__Secure_1PSIDTS")
 chatbot = Chatbot(Secure_1PSID, Secure_1PSIDTS)
 
 chatbot.ask("Hello, how are you?")

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Go to https://bard.google.com/
 
 ```bash
 $ python3 -m Bard -h
-usage: Bard.py [-h] --session $BARD__Secure_1PSID --session_ts $BARD__Secure_1PSIDTS
+usage: Bard.py [-h] --session <__Secure-1PSID> --session_ts <__Secure-1PSIDTS>
 
 options:
   -h, --help         show this help message and exit
@@ -27,8 +27,8 @@ options:
 ### Quick mode
 ```
 $ export BARD_QUICK="true"
-$ export BARD__Secure_1PSID="<__Secure_1PSID>"
-$ export BARD__Secure_1PSIDTS="<__Secure_1PSIDTS>"
+$ export BARD__Secure_1PSID="<__Secure-1PSID>"
+$ export BARD__Secure_1PSIDTS="<__Secure-1PSIDTS>"
 $ python3 -m Bard
 ```
 Environment variables can be placed in .zshrc.
@@ -39,8 +39,8 @@ Example bash shortcut:
 # USAGE2: echo "QUESTION" | bard
 bard () {
 	export BARD_QUICK=true
-	export BARD__Secure_1PSID==<REDACTED>.
-	export BARD__Secure_1PSIDTS==<REDACTED>.
+	export BARD__Secure_1PSID=<__Secure-1PSID>
+	export BARD__Secure_1PSIDTS=<__Secure-1PSIDTS>
 	python3 -m Bard "${@:-$(</dev/stdin)}" | tail -n+7
 }
 ```

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="GoogleBard",
-    version="2.0.0",
+    version="2.1.0",
     license="MIT License",
     author="Antonio Cheong",
     author_email="acheong@student.dalat.org",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="GoogleBard",
-    version="2.1.0",
+    version="2.1.1",
     license="MIT License",
     author="Antonio Cheong",
     author_email="acheong@student.dalat.org",

--- a/src/Bard.py
+++ b/src/Bard.py
@@ -88,8 +88,10 @@ class AsyncChatbot:
     """
     A class to interact with Google Bard.
     Parameters
-        session_id: str
-            The __Secure-1PSID cookie.
+        session: str
+            The __Secure_1PSID cookie.
+        session-ts: str
+            The __Secure_1PSIDTS cookie.
         proxy: str
         timeout: int
             Request timeout in seconds.
@@ -223,7 +225,7 @@ class AsyncChatbot:
             or self.secure_1psid[-1] != "."
         ):
             raise Exception(
-                "Enter correct __Secure-1PSID and __Secure-1PSIDTS value. __Secure-1PSID value must end with a single dot. ",
+                "Enter correct __Secure_1PSID and __Secure_1PSIDTS value. __Secure_1PSID value must end with a single dot. ",
             )
         resp = await self.session.get(
             "https://bard.google.com/",
@@ -237,7 +239,7 @@ class AsyncChatbot:
         SNlM0e = re.search(r"SNlM0e\":\"(.*?)\"", resp.text)
         if not SNlM0e:
             raise Exception(
-                "SNlM0e value not found in response. Check __Secure-1PSID value.",
+                "SNlM0e value not found in response. Check __Secure_1PSID value.",
             )
         return SNlM0e.group(1)
 
@@ -307,11 +309,11 @@ if __name__ == "__main__":
     )
     console = Console()
     if os.getenv("BARD_QUICK"):
-        Secure_1PSID = os.getenv("BARD___Secure-1PSID")
-        Secure_1PSIDTS = os.getenv("BARD__Secure-1PSIDTS")
+        Secure_1PSID = os.getenv("BARD__Secure_1PSID")
+        Secure_1PSIDTS = os.getenv("BARD__Secure_1PSIDTS")
         if not (Secure_1PSID and Secure_1PSIDTS):
             print(
-                "BARD___Secure-1PSID or BARD__Secure-1PSIDTS environment variable not set.",
+                "BARD__Secure_1PSID or BARD__Secure_1PSIDTS environment variable not set.",
             )
             sys.exit(1)
         chatbot = Chatbot(Secure_1PSID, Secure_1PSIDTS)

--- a/src/Bard.py
+++ b/src/Bard.py
@@ -90,7 +90,7 @@ class AsyncChatbot:
     Parameters
         session: str
             The __Secure_1PSID cookie.
-        session-ts: str
+        session_ts: str
             The __Secure_1PSIDTS cookie.
         proxy: str
         timeout: int


### PR DESCRIPTION
got rid of dashes in environmental vars, because my linux does not like 'em.
some minor changes to documentation and readme to reflect these changes.